### PR TITLE
solving `additional_authorized_imports` blocked by `BASE_BUILTIN_MODULES`

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -1240,7 +1240,7 @@ class CodeAgent(MultiStepAgent):
         **kwargs,
     ):
         self.additional_authorized_imports = additional_authorized_imports if additional_authorized_imports else []
-        self.authorized_imports = sorted(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
+        self.authorized_imports = sorted(set(BASE_BUILTIN_MODULES) & set(self.additional_authorized_imports))
         self.max_print_outputs_length = max_print_outputs_length
         prompt_templates = prompt_templates or yaml.safe_load(
             importlib.resources.files("smolagents.prompts").joinpath("code_agent.yaml").read_text()


### PR DESCRIPTION
solving `additional_authorized_imports` blocked by `BASE_BUILTIN_MODULES`. 
<br>
changing 
```py
self.authorized_imports = sorted(set(BASE_BUILTIN_MODULES) | set(self.additional_authorized_imports))
```
into
```py
self.authorized_imports = sorted(set(BASE_BUILTIN_MODULES) & set(self.additional_authorized_imports))
```